### PR TITLE
Correct endianness detection for OS X universal builds.

### DIFF
--- a/liblcdf/md5.c
+++ b/liblcdf/md5.c
@@ -98,7 +98,7 @@ transform(MD5_CONTEXT *ctx, const unsigned char *data)
 	uint32_t D = ctx->D;
 	uint32_t *cwp = correct_words;
 
-#if WORDS_BIGENDIAN
+#if WORDS_BIGENDIAN || defined(__APPLE__) && defined(__BIG_ENDIAN__)
 	{
 		int i;
 		unsigned char *p2, *p1;
@@ -111,7 +111,7 @@ transform(MD5_CONTEXT *ctx, const unsigned char *data)
 			p2[0] = *p1++;
 		}
 	}
-#elif WORDS_LITTLEENDIAN
+#elif WORDS_LITTLEENDIAN || defined(__APPLE__) && defined(__LITTLE_ENDIAN__)
 	memcpy(correct_words, data, 64);
 #else
 # error "Neither WORDS_BIGENDIAN nor WORDS_LITTLEENDIAN is defined!"
@@ -307,10 +307,10 @@ do_final(MD5_CONTEXT *hd)
 	transform(hd, hd->buf);
 
 	p = hd->buf;
-#if WORDS_BIGENDIAN
+#if WORDS_BIGENDIAN || defined(__APPLE__) && defined(__BIG_ENDIAN__)
 #define X(a) do { *p++ = hd->a      ; *p++ = hd->a >> 8;      \
 		  *p++ = hd->a >> 16; *p++ = hd->a >> 24; } while(0)
-#elif WORDS_LITTLEENDIAN
+#elif WORDS_LITTLEENDIAN || defined(__APPLE__) && defined(__LITTLE_ENDIAN__)
 	/*#define X(a) do { *(uint32_t*)p = hd->##a ; p += 4; } while(0)*/
 	/* Unixware's cpp doesn't like the above construct so we do it his way:
 	 * (reported by Allan Clark) */

--- a/liblcdf/string.cc
+++ b/liblcdf/string.cc
@@ -641,9 +641,9 @@ String::hashcode(const char *begin, const char *end)
 #undef get16
 #if !HAVE_INDIFFERENT_ALIGNMENT
     } else {
-# if WORDS_BIGENDIAN
+# if WORDS_BIGENDIAN || defined(__APPLE__) && defined(__BIG_ENDIAN__)
 #  define get16(p) (((unsigned char) (p)[0] << 8) + (unsigned char) (p)[1])
-# elif WORDS_LITTLEENDIAN
+# elif WORDS_LITTLEENDIAN || defined(__APPLE__) && defined(__LITTLE_ENDIAN__)
 #  define get16(p) ((unsigned char) (p)[0] + ((unsigned char) (p)[1] << 8))
 # else
 #  error "unknown byte order"


### PR DESCRIPTION
The configure script correctly detects universal compilation (e.g., `clang -arch x86_64 -arch i386`) and defines neither `WORDS_BIGENDIAN` nor `WORDS_LITTLEENDIAN`. However, the build then errors out because the
endianness checks assume that at least one of `WORDS_BIGENDIAN` and `WORDS_LITTLEENDIAN` are defined. Using the standard OS X endianness macros fixes this.

(Original bug report: http://trac.macports.org/ticket/40401)
