### PR TITLE
Typo fix in manpage of t1reencode

### DIFF
--- a/t1reencode/t1reencode.1
+++ b/t1reencode/t1reencode.1
@@ -8,7 +8,7 @@
 ..
 .TH T1REENCODE 1 "LCDF Typetools" "Version \*V"
 .SH NAME
-t1reencode \- reencode a PostScript Type 1 font
+t1reencode \- re-encode a PostScript Type 1 font
 .SH SYNOPSIS
 .B t1reencode
 \%\-e ENCODING
@@ -17,7 +17,7 @@ t1reencode \- reencode a PostScript Type 1 font
 .RI [ outputfile ]
 .SH DESCRIPTION
 .BR T1reencode
-changes a PostScript Type\~1 font's embedded encoding.  The reencoded font
+changes a PostScript Type\~1 font's embedded encoding.  The re-encoded font
 is written to the standard output (but see the
 .B \-\-output
 option).  If no input font file is supplied, 
@@ -151,14 +151,14 @@ Print the version number and some short non-warranty information and exit.
 '
 .SH "RETURN VALUES"
 .B T1reencode
-exits with value 0 if a reencoded font was successfully generated, and 1
+exits with value 0 if a re-encoded font was successfully generated, and 1
 otherwise.
 '
 .SH "NOTES"
 .LP
 .B T1reencode
 should be used only in special situations.  It's generally much better to
-use PostScript commands to reencode a font; for instance, executing the
+use PostScript commands to re-encode a font; for instance, executing the
 PostScript commands to generate two differently-encoded versions of a
 single font will take up much less memory than loading two
 .BR t1reencode d
@@ -166,7 +166,7 @@ fonts.
 '
 .SH "EXAMPLES"
 .PP
-This command reencodes Frutiger Roman in the ISO Latin\~1 encoding.  The new
+This command re-encodes Frutiger Roman in the ISO Latin\~1 encoding.  The new
 font will have the PostScript name Frutiger-RomanISOLatin1Encoding.
 .Sp
 .nf


### PR DESCRIPTION
Submitting this patch as Debian maintainer of this tool. This was flagged in our package lint system (lintian). Please consider merging this.
