### PR TITLE
[WIP] TeX Live patches for Windows

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -7,6 +7,7 @@
 #ifdef WIN32
 # ifdef __MINGW32__
 #  include <winsock2.h>
+#  include <windows.h>
 # else
 #  include <win32lib.h>
 # endif

--- a/otftotfm/automatic.cc
+++ b/otftotfm/automatic.cc
@@ -334,7 +334,11 @@ update_odir(int o, String file, ErrorHandler *errh)
     if (!success && writable_texdir.find_left('\'') < 0 && directory.find_left('\'') < 0 && file.find_left('\'') < 0) {
         // look for mktexupd script
         if (!mktexupd_tried) {
+#ifdef _WIN32
+            mktexupd = "mktexupd.exe";
+#else
             mktexupd = kpsei_string(kpsei_find_file("mktexupd", KPSEI_FMT_WEB2C));
+#endif
             mktexupd_tried = true;
         }
 

--- a/otftotfm/automatic.cc
+++ b/otftotfm/automatic.cc
@@ -126,7 +126,16 @@ look_for_writable_texdir(const char *path_variable, bool create)
 static void
 find_writable_texdir(ErrorHandler *errh, const char *)
 {
-    look_for_writable_texdir("$TEXMFVAR", true);
+    // Check if TEXMFVAR is writable.
+    // Some distributions like W32TeX do not have TEXMFVAR defined,
+    // in which case we check TEXMFLOCAL.
+    char *p = kpsei_var_value("TEXMFVAR");
+    if (p == NULL)
+        look_for_writable_texdir("$TEXMFLOCAL", true);
+    else {
+        free (p);
+        look_for_writable_texdir("$TEXMFVAR", true);
+    }
     if (!writable_texdir)
         look_for_writable_texdir("$VARTEXMF", false);
     if (!writable_texdir)

--- a/otftotfm/automatic.cc
+++ b/otftotfm/automatic.cc
@@ -39,7 +39,9 @@
 #include <algorithm>
 
 #ifdef WIN32
-# define mkdir(dir, access) mkdir(dir)
+# include <io.h>
+# include <direct.h>
+# define mkdir(dir, access) _mkdir(dir)
 # define COPY_CMD "copy"
 # define CMD_SEP "&"
 #else

--- a/otftotfm/automatic.cc
+++ b/otftotfm/automatic.cc
@@ -313,7 +313,7 @@ update_odir(int o, String file, ErrorHandler *errh)
     String ls_r = writable_texdir + "ls-R";
     bool success = false;
     if (access(ls_r.c_str(), R_OK) >= 0) // make sure it already exists
-        if (FILE *f = fopen(ls_r.c_str(), "a")) {
+        if (FILE *f = fopen(ls_r.c_str(), "ab")) {
             fprintf(f, "./%s:\n%s\n", directory.c_str(), file.c_str());
             success = true;
             fclose(f);
@@ -677,7 +677,7 @@ update_autofont_map(const String &fontname, String mapline, ErrorHandler *errh)
 #endif
             {
                 fclose(f);
-                f = fopen(map_file.c_str(), "w");
+                f = fopen(map_file.c_str(), "wb");
                 fd = fileno(f);
             }
 

--- a/otftotfm/kpseinterface.c
+++ b/otftotfm/kpseinterface.c
@@ -21,6 +21,7 @@
 #include <kpathsea/expand.h>
 #include <kpathsea/c-pathch.h>
 #include <kpathsea/tex-file.h>
+#include <kpathsea/variable.h>
 #include "kpseinterface.h"
 
 int kpsei_env_sep_char = ENV_SEP;
@@ -47,6 +48,12 @@ char*
 kpsei_path_expand(const char* path)
 {
     return kpse_path_expand(path);
+}
+
+char*
+kpsei_var_value(const char *name)
+{
+    return kpse_var_value(name);
 }
 
 char*

--- a/otftotfm/kpseinterface.h
+++ b/otftotfm/kpseinterface.h
@@ -7,6 +7,7 @@ extern "C" {
 void kpsei_init(const char* argv0, const char* progname);
 extern int kpsei_env_sep_char;
 char* kpsei_path_expand(const char* path); /* free() result */
+char* kpsei_var_value(const char *name);
 enum { KPSEI_FMT_WEB2C, KPSEI_FMT_ENCODING, KPSEI_FMT_TYPE1,
        KPSEI_FMT_OTHER_TEXT, KPSEI_FMT_MAP, KPSEI_FMT_TRUETYPE,
        KPSEI_FMT_OPENTYPE, KPSEI_FMT_TYPE42 };

--- a/otftotfm/otftotfm.cc
+++ b/otftotfm/otftotfm.cc
@@ -16,6 +16,7 @@
 #endif
 #ifdef WIN32
 # define _USE_MATH_DEFINES
+# include <io.h>
 #endif
 #include <efont/psres.hh>
 #include <efont/t1rw.hh>

--- a/otftotfm/otftotfm.cc
+++ b/otftotfm/otftotfm.cc
@@ -590,7 +590,7 @@ output_pl(Metrics &metrics, const String &ps_name, int boundary_char,
 
     if (verbose)
         errh->message("creating %s", filename.c_str());
-    FILE *f = fopen(filename.c_str(), "w");
+    FILE *f = fopen(filename.c_str(), "wb");
     if (!f) {
         errh->error("%s: %s", filename.c_str(), strerror(errno));
         return;
@@ -1048,7 +1048,7 @@ write_encoding_file(String &filename, const String &encoding_name,
 #endif
     {
         fclose(f);
-        f = fopen(filename.c_str(), "w");
+        f = fopen(filename.c_str(), "wb");
         fd = fileno(f);
     }
 

--- a/t1dotlessj/t1dotlessj.cc
+++ b/t1dotlessj/t1dotlessj.cc
@@ -410,10 +410,10 @@ particular purpose.\n");
     // write it to output
     if (!outputf)
 	outputf = stdout;
-    if (binary) {
 #if defined(_MSDOS) || defined(_WIN32)
-	_setmode(_fileno(outputf), _O_BINARY);
+    _setmode(_fileno(outputf), _O_BINARY);
 #endif
+    if (binary) {
 	Type1PFBWriter w(outputf);
 	dotless_font->write(w);
     } else {

--- a/t1rawafm/t1rawafm.cc
+++ b/t1rawafm/t1rawafm.cc
@@ -359,6 +359,9 @@ particular purpose.\n");
         if (!outf)
             errh->fatal("%s: %s", output_file, strerror(errno));
     }
+#if defined(_MSDOS) || defined(_WIN32)
+    _setmode(_fileno(outf), _O_BINARY);
+#endif
 
     write_afm(outf, font);
 

--- a/t1reencode/t1reencode.cc
+++ b/t1reencode/t1reencode.cc
@@ -1094,10 +1094,10 @@ particular purpose.\n");
 	if (!outf)
 	    errh->fatal("%s: %s", output_file, strerror(errno));
     }
-    if (binary) {
 #if defined(_MSDOS) || defined(_WIN32)
-	_setmode(_fileno(outf), _O_BINARY);
+    _setmode(_fileno(outf), _O_BINARY);
 #endif
+    if (binary) {
 	Type1PFBWriter w(outf);
 	font->write(w);
     } else {

--- a/t1testpage/t1testpage.cc
+++ b/t1testpage/t1testpage.cc
@@ -665,6 +665,9 @@ particular purpose.\n");
 	if (!outf)
 	    errh->fatal("%s: %s", output_file, strerror(errno));
     }
+#if defined(_MSDOS) || defined(_WIN32)
+    _setmode(_fileno(outf), _O_BINARY);
+#endif
 
     //font->undo_synthetic();
 


### PR DESCRIPTION
This is a set of patches as currently used by TeX Live. I'm not the author of them (some of them were contributed by Peter Breitenlohner, some by Akira Kakuto), but I'm submitting them unchanged for now, so that you can make a code review and we can try to find a way to end up patch-free in TeX Live.

(I suspect that some of the patches were `ifdef`-ed to `W32TeX` just to minimize the impact elsewhere, but maybe some could be used outside of W32TeX as well.)

The sources need to work:
- from msys2 / native MinGW on Windows
- cross-compilations with 32-bit and 64-bit mingw-w64 from either Linux or Mac
- from Visual Studio (I'm not yet sure how to test that; Akira has some zips with visual studio projects on the w32tex website, I would need to look at those)

I will edit history and commit messages as necessary.

@kberry @norbusan, see: #17, #20