### PR TITLE
Add CLI help info about -u

### DIFF
--- a/otfinfo/otfinfo.cc
+++ b/otfinfo/otfinfo.cc
@@ -126,6 +126,7 @@ Query options:\n\
   -g, --glyphs                 Report font%,s glyph names.\n\
   -t, --tables                 Report font%,s OpenType tables.\n\
   -T, --dump-table NAME        Output font%,s %<NAME%> table.\n\
+  -u, --unicode                Report font%,s supported Unicode code points.\n\
 \n\
 Other options:\n\
       --script=SCRIPT[.LANG]   Set script used for --features [latn].\n\


### PR DESCRIPTION
The option was described in the manual, but not shown in the built-in help.