### PR TITLE
configure.ac: fix the msys2 build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -307,8 +307,9 @@ Cannot find a definition for ntohs and/or ntohl!
 =========================================])
 fi
 AC_LANG([C])
-AC_SEARCH_LIBS([ntohs], [-lnet -lwinsock32])
-
+AC_SEARCH_LIBS([ntohs], [ws2_32 net winsock32], [], [
+    AC_MSG_ERROR([Cannot find a library providing ntohs])
+])
 
 dnl
 dnl is va_list addressable?


### PR DESCRIPTION
See: https://github.com/kohler/lcdf-typetools/issues/22

Apparently the import library is called `ws_32` on the mingw64 platform, search for that in addition to the other winsock libraries. If no library is found, bail out the compilation rather than silently continuing, which causes linker errors later.

This also fixes issues using `-l` in the AC_SEARCH_LIBS call. According to [the documentation](https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Libraries.html), you should only put the library name in this macro call, not he compiler's linker flag.

This worked for me in mingw64, did not test other targets.